### PR TITLE
dac workflow: change local actions paths to absolute paths

### DIFF
--- a/.github/workflows/dac.yaml
+++ b/.github/workflows/dac.yaml
@@ -81,24 +81,24 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install necessary tools
-        uses: ./actions/setup_environment
+        uses: perses/github-actions/actions/setup_environment@main
         with:
           enable_go: true
           enable_cue: true
 
       - name: Install percli
-        uses: ./actions/install_percli
+        uses: perses/github-actions/actions/install_percli@main
         with:
           cli_version: "latest"
 
       - name: Build the dashboards
-        uses: ./actions/build_dac
+        uses: perses/github-actions/actions/build_dac@main
         with:
           directory: ${{ inputs.directory }}
           file: ${{ inputs.file }}
 
       - name: Login to the API server
-        uses: ./actions/login
+        uses: perses/github-actions/actions/login@main
         with:
           url: ${{ inputs.url }}
           username: ${{ secrets.username }}
@@ -110,14 +110,14 @@ jobs:
           insecure-skip-tls-verify: ${{ inputs.insecure-skip-tls-verify }}
 
       - name: Validate the dashboards
-        uses: ./actions/validate_resources
+        uses: perses/github-actions/actions/validate_resources@main
         with:
           directory: ./built
           online: ${{ inputs.server-validation }}
 
       - name: Preview the dashboards
         if: ${{ github.event_name == 'pull_request' && !inputs.skip-preview }}
-        uses: ./actions/preview_dashboards
+        uses: perses/github-actions/actions/preview_dashboards@main
         with:
           directory: ./built
           project: ${{ inputs.project }}
@@ -126,14 +126,14 @@ jobs:
 
       - name: Generate dashboards diffs
         if: ${{ github.event_name == 'pull_request' && !inputs.skip-diff }}
-        uses: ./actions/diff_dashboards
+        uses: perses/github-actions/actions/diff_dashboards@main
         with:
           directory: ./built
           project: ${{ inputs.project }}
 
       - name: Deploy the dashboards
         if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && !inputs.skip-deploy }}
-        uses: ./actions/apply_resources
+        uses: perses/github-actions/actions/apply_resources@main
         with:
           directory: ./built
           project: ${{ inputs.project }}

--- a/.github/workflows/test_dac.yaml
+++ b/.github/workflows/test_dac.yaml
@@ -18,5 +18,6 @@ jobs:
       url: https://demo.perses.dev
       directory: ./testdata/dac_folder
       server-validation: true
+    secrets:
       username: ${{ secrets.TEST_USERNAME }}
       password: ${{ secrets.TEST_PASSWORD }}


### PR DESCRIPTION
This is required to allow for external re-usage of the workflow, otherwise the paths don't resolve.