### PR TITLE
diff dashboards: remove output folder creation

### DIFF
--- a/actions/diff_dashboards/action.yaml
+++ b/actions/diff_dashboards/action.yaml
@@ -15,12 +15,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Create the output folder
-      run: |
-        # Remove this step when a release embedding https://github.com/perses/perses/pull/2484 is available.
-        mkdir -p built
-      shell: bash
-
     - name: Run the `dac diff` command
       run: |
         percli dac diff \


### PR DESCRIPTION
this step is no longer needed since v0.50.0-rc.0